### PR TITLE
OAuth support as nextcloud login provider

### DIFF
--- a/interlab/oauth_validator.py
+++ b/interlab/oauth_validator.py
@@ -1,0 +1,14 @@
+from oauth2_provider.oauth2_validators import OAuth2Validator
+
+class CustomOAuth2Validator(OAuth2Validator):
+
+    def get_additional_claims(self, request):
+        return {
+            'sub': request.user.username,
+            'mail': request.user.email,
+            'name': ' '.join([request.user.first_name, request.user.last_name]),
+            'given_name': request.user.first_name,
+            'last_name': request.user.last_name,
+            'groups': [g.name for g in request.user.groups.all()],
+            'is_admin': request.user.is_staff
+        }

--- a/interlab/settings.py
+++ b/interlab/settings.py
@@ -28,8 +28,8 @@ SECRET_KEY = '=*fyf15@$mer21(^jzxxbxwa4gn!qpi^@azhy#7ol9vh*ezqz('
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
-
+ALLOWED_HOSTS = ['*']
+CORS_ORIGIN_ALLOW_ALL = True
 
 # Application definition
 
@@ -125,8 +125,11 @@ TEMPLATES = [
 
 
 MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
     'cms.middleware.utils.ApphookReloadMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'oauth2_provider.middleware.OAuth2TokenMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
@@ -149,6 +152,7 @@ INSTALLED_APPS = [
     'django.contrib.sitemaps',
     'django.contrib.staticfiles',
     'django.contrib.messages',
+    'oauth2_provider',
     'cms',
     'menus',
     'sekizai',
@@ -232,3 +236,13 @@ THUMBNAIL_PROCESSORS = (
     'filer.thumbnail_processors.scale_and_crop_with_subject_location',
     'easy_thumbnails.processors.filters'
 )
+
+OAUTH2_PROVIDER = {
+    "OIDC_ENABLED": True,
+    "SCOPES": {
+        "openid": "OpenID Connect scope",
+        # ... any other scopes that you use
+    },
+    "OAUTH2_VALIDATOR_CLASS": "interlab.oauth_validator.CustomOAuth2Validator",
+    # ... any other settings you want
+}

--- a/interlab/templates/registration/login.html
+++ b/interlab/templates/registration/login.html
@@ -1,0 +1,13 @@
+{% extends CMS_TEMPLATE %}
+{% load cms_tags %}
+
+{% block content %}
+
+<h2>Log In</h2>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Log In</button>
+</form>
+
+{% endblock %}

--- a/interlab/urls.py
+++ b/interlab/urls.py
@@ -13,6 +13,8 @@ urlpatterns = [
 
 urlpatterns += [
     path("admin/", admin.site.urls),
+    path("accounts/", include('django.contrib.auth.urls')),
+    path("o/", include("oauth2_provider.urls", namespace="oauth2_provider")),
     path("", include("cms.urls")),
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 django-cms>=3.8,<3.9
-djangocms-admin-style>=2.0,<3.0
 django-treebeard>=4.4,<4.5
+django-oauth-toolkit>=1.5
+django-cors-headers>=3.7
+djangocms-admin-style>=2.0,<3.0
 psycopg2-binary>=2.8
 djangocms-text-ckeditor>=4.0,<5.0
 djangocms-link>=3.0,<4.0


### PR DESCRIPTION
In order to setup NextCloud follow instruction from : https://github.com/pulsejet/nextcloud-oidc-login

On Django side add an application in Django OAuth Toolkit as : 
* Client Type : Confidential
* Authorization Grant Type : Authorization Code
* Algorithm : HMAC with SHA 2 - 256
* Client ID and Client Secret as setup in oidc
* Redirect URI : https://<changeme>/apps/oidc_login/oidc